### PR TITLE
[BUGFIX] Missing ACL section for customers configuration

### DIFF
--- a/app/code/local/Dealer4dealer/Xcore/etc/adminhtml.xml
+++ b/app/code/local/Dealer4dealer/Xcore/etc/adminhtml.xml
@@ -32,6 +32,9 @@
                                     <xcore_sales>
                                         <title>Dealer4Dealer - Sales settings</title>
                                     </xcore_sales>
+                                    <xcore_customers>
+                                        <title>Dealer4Dealer - Customer settings</title>
+                                    </xcore_customers>
                                 </children>
                             </config>
                         </children>


### PR DESCRIPTION
`Adminhtml.xml` was missing a section for `xcore_customers` causing a permissions warning to be displayed