### PR TITLE
Everything seems to work except xcoreCustomerCustomer methods?

### DIFF
--- a/app/code/local/Dealer4dealer/Xcore/Model/Customer/Customer/Api/V2.php
+++ b/app/code/local/Dealer4dealer/Xcore/Model/Customer/Customer/Api/V2.php
@@ -2,6 +2,50 @@
 class Dealer4dealer_Xcore_Model_Customer_Customer_Api_V2 extends Mage_Customer_Model_Customer_Api_V2
 {
     /**
+     * Retrieve customers data by filters and limit
+     *
+     * @param  object|array $filters
+     * @param null $limit
+     * @return array
+     */
+    public function items($filters, $limit = null)
+    {
+        $collection = Mage::getModel('customer/customer')->getCollection()->addAttributeToSelect('*');
+
+        if($limit) {
+            $collection->setOrder('updated_at', 'ASC');
+            $collection->setPageSize($limit);
+        }
+
+        /** @var $apiHelper Mage_Api_Helper_Data */
+        $apiHelper = Mage::helper('api');
+        $filters = $apiHelper->parseFilters($filters, $this->_mapAttributes);
+        try {
+            foreach ($filters as $field => $value) {
+                $collection->addFieldToFilter($field, $value);
+            }
+        } catch (Mage_Core_Exception $e) {
+            $this->_fault('filters_invalid', $e->getMessage());
+        }
+        $result = array();
+        foreach ($collection as $customer) {
+            $data = $customer->toArray();
+            $row  = array();
+            foreach ($this->_mapAttributes as $attributeAlias => $attributeCode) {
+                $row[$attributeAlias] = (isset($data[$attributeCode]) ? $data[$attributeCode] : null);
+            }
+            foreach ($this->getAllowedAttributes($customer) as $attributeCode => $attribute) {
+                if (isset($data[$attributeCode])) {
+                    $row[$attributeCode] = $data[$attributeCode];
+                }
+            }
+            $result[] = $row;
+        }
+
+        return $result;
+    }
+
+    /**
      * Retrieve customer data
      *
      * @param int $customerId

--- a/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Api/V2.php
+++ b/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Api/V2.php
@@ -2,6 +2,65 @@
 class Dealer4dealer_Xcore_Model_Sales_Order_Api_V2 extends Mage_Sales_Model_Order_Api_V2
 {
     /**
+     * Retrieve list of orders. Filtration could be applied
+     *
+     * @param null|object|array $filters
+     * @param null $limit
+     * @return array
+     */
+    public function items($filters = null, $limit = null)
+    {
+        $orders = array();
+
+        //TODO: add full name logic
+        $billingAliasName = 'billing_o_a';
+        $shippingAliasName = 'shipping_o_a';
+
+        /** @var $orderCollection Mage_Sales_Model_Mysql4_Order_Collection */
+        $orderCollection = Mage::getModel("sales/order")->getCollection();
+
+        if($limit) {
+            $orderCollection->setOrder('updated_at', 'ASC');
+            $orderCollection->setPageSize($limit);
+        }
+
+        $billingFirstnameField = "$billingAliasName.firstname";
+        $billingLastnameField = "$billingAliasName.lastname";
+        $shippingFirstnameField = "$shippingAliasName.firstname";
+        $shippingLastnameField = "$shippingAliasName.lastname";
+        $orderCollection->addAttributeToSelect('*')
+                        ->addAddressFields()
+                        ->addExpressionFieldToSelect('billing_firstname', "{{billing_firstname}}",
+                                                     array('billing_firstname' => $billingFirstnameField))
+                        ->addExpressionFieldToSelect('billing_lastname', "{{billing_lastname}}",
+                                                     array('billing_lastname' => $billingLastnameField))
+                        ->addExpressionFieldToSelect('shipping_firstname', "{{shipping_firstname}}",
+                                                     array('shipping_firstname' => $shippingFirstnameField))
+                        ->addExpressionFieldToSelect('shipping_lastname', "{{shipping_lastname}}",
+                                                     array('shipping_lastname' => $shippingLastnameField))
+                        ->addExpressionFieldToSelect('billing_name', "CONCAT({{billing_firstname}}, ' ', {{billing_lastname}})",
+                                                     array('billing_firstname' => $billingFirstnameField, 'billing_lastname' => $billingLastnameField))
+                        ->addExpressionFieldToSelect('shipping_name', 'CONCAT({{shipping_firstname}}, " ", {{shipping_lastname}})',
+                                                     array('shipping_firstname' => $shippingFirstnameField, 'shipping_lastname' => $shippingLastnameField)
+                        );
+
+        /** @var $apiHelper Mage_Api_Helper_Data */
+        $apiHelper = Mage::helper('api');
+        $filters = $apiHelper->parseFilters($filters, $this->_attributesMap['order']);
+        try {
+            foreach ($filters as $field => $value) {
+                $orderCollection->addFieldToFilter($field, $value);
+            }
+        } catch (Mage_Core_Exception $e) {
+            $this->_fault('filters_invalid', $e->getMessage());
+        }
+        foreach ($orderCollection as $order) {
+            $orders[] = $this->_getAttributes($order, 'order');
+        }
+        return $orders;
+    }
+
+    /**
      * Add custom fields to the sales order api.
      * See README.md for more information.
      *

--- a/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Creditmemo/Api/V2.php
+++ b/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Creditmemo/Api/V2.php
@@ -2,6 +2,38 @@
 class Dealer4dealer_Xcore_Model_Sales_Order_Creditmemo_Api_V2 extends Mage_Sales_Model_Order_Creditmemo_Api_V2
 {
     /**
+     * Retrieve credit memos list. Filtration could be applied. Also, limit.
+     *
+     * @param null|object|array $filters
+     * @param null $limit
+     * @return array
+     */
+    public function items($filters = null, $limit = null)
+    {
+        $creditmemos = array();
+        /** @var $apiHelper Mage_Api_Helper_Data */
+        $apiHelper = Mage::helper('api');
+        $filters = $apiHelper->parseFilters($filters, $this->_attributesMap['creditmemo']);
+        /** @var $creditmemoModel Mage_Sales_Model_Order_Creditmemo */
+        $creditmemoModel = Mage::getModel('sales/order_creditmemo');
+        try {
+            $creditMemoCollection = $creditmemoModel->getFilteredCollectionItems($filters);
+
+            if($limit) {
+                $creditMemoCollection->setOrder('updated_at', 'ASC');
+                $creditMemoCollection->setPageSize($limit);
+            }
+
+            foreach ($creditMemoCollection as $creditmemo) {
+                $creditmemos[] = $this->_getAttributes($creditmemo, 'creditmemo');
+            }
+        } catch (Exception $e) {
+            $this->_fault('invalid_filter', $e->getMessage());
+        }
+        return $creditmemos;
+    }
+
+    /**
      * Add custom fields to the sales order api.
      * See README.md for more information.
      *

--- a/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Shipment/Api/V2.php
+++ b/app/code/local/Dealer4dealer/Xcore/Model/Sales/Order/Shipment/Api/V2.php
@@ -3,6 +3,48 @@
 class Dealer4dealer_Xcore_Model_Sales_Order_Shipment_Api_V2 extends Mage_Sales_Model_Order_Shipment_Api_V2
 {
     /**
+     * Retrieve shipments by filters and limit
+     *
+     * @param null|object|array $filters
+     * @param null $limit
+     * @return array
+     */
+    public function items($filters = null, $limit = null)
+    {
+        $shipments = array();
+        //TODO: add full name logic
+        $shipmentCollection = Mage::getResourceModel('sales/order_shipment_collection')
+                                  ->addAttributeToSelect('increment_id')
+                                  ->addAttributeToSelect('created_at')
+                                  ->addAttributeToSelect('total_qty')
+                                  ->joinAttribute('shipping_firstname', 'order_address/firstname', 'shipping_address_id', null, 'left')
+                                  ->joinAttribute('shipping_lastname', 'order_address/lastname', 'shipping_address_id', null, 'left')
+                                  ->joinAttribute('order_increment_id', 'order/increment_id', 'order_id', null, 'left')
+                                  ->joinAttribute('order_created_at', 'order/created_at', 'order_id', null, 'left');
+
+        if($limit) {
+            $shipmentCollection->setOrder('updated_at', 'ASC');
+            $shipmentCollection->setPageSize($limit);
+        }
+
+        /** @var $apiHelper Mage_Api_Helper_Data */
+        $apiHelper = Mage::helper('api');
+        try {
+            $filters = $apiHelper->parseFilters($filters, $this->_attributesMap['shipment']);
+            foreach ($filters as $field => $value) {
+                $shipmentCollection->addFieldToFilter($field, $value);
+            }
+        } catch (Mage_Core_Exception $e) {
+            $this->_fault('filters_invalid', $e->getMessage());
+        }
+        foreach ($shipmentCollection as $shipment) {
+            $shipments[] = $this->_getAttributes($shipment, 'shipment');
+        }
+
+        return $shipments;
+    }
+
+    /**
      * Create new shipment for order
      *
      * @param string $orderIncrementId

--- a/app/code/local/Dealer4dealer/Xcore/etc/api.xml
+++ b/app/code/local/Dealer4dealer/Xcore/etc/api.xml
@@ -1,64 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <config>
     <api>
         <resources>
-            <xcore_catalog_product translate="title" module="dealer4dealer_xcore">
-                <model>dealer4dealer_xcore/catalog_product_api</model>
+            <xcore_catalog_product module="dealer4dealer_xcore" translate="title">
                 <title>Products</title>
+                <model>dealer4dealer_xcore/catalog_product_api</model>
                 <methods>
-                    <list translate="title" module="dealer4dealer_xcore">
-                        <title>List of Products</title>
-                        <method>items</method>
-                        <acl>catalog/product/info</acl>
-                    </list>
-                    <attributeTierPriceCreate translate="title" module="dealer4dealer_xcore">
-                        <title>Create bulk product tier prices</title>
+                    <attributeTierPriceCreate module="dealer4dealer_xcore" translate="title">
                         <acl>catalog/product/update</acl>
+                        <title>Create bulk product tier prices</title>
                     </attributeTierPriceCreate>
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>catalog/product/info</acl>
+                        <method>items</method>
+                        <title>List of Products</title>
+                    </list>
                 </methods>
             </xcore_catalog_product>
-            <xcore_tax_class_product>
-                <model>dealer4dealer_xcore/tax_class_product_api</model>
-                <title>Product Tax Classes</title>
-                <methods>
-                    <list translate="title" module="dealer4dealer_xcore">
-                        <method>items</method>
-                        <title>Retrieve a list of product tax classes</title>
-                        <acl>catalog/product/info</acl>
-                    </list>
-                </methods>
-            </xcore_tax_class_product>
             <xcore_catalog_product_attribute>
-                <model>dealer4dealer_xcore/catalog_product_attribute_api</model>
                 <title>Product Attributes</title>
+                <model>dealer4dealer_xcore/catalog_product_attribute_api</model>
                 <methods>
-                    <attributeValues translate="title" module="dealer4dealer_xcore">
-                        <title>List of attribute values</title>
+                    <attributeValues module="dealer4dealer_xcore" translate="title">
                         <acl>catalog/product/info</acl>
+                        <title>List of attribute values</title>
                     </attributeValues>
-                    <tierPriceCreate translate="title" module="dealer4dealer_xcore">
-                        <title>Add product tier prices</title>
+                    <tierPriceCreate module="dealer4dealer_xcore" translate="title">
                         <acl>catalog/product/update</acl>
+                        <title>Add product tier prices</title>
                     </tierPriceCreate>
                 </methods>
                 <faults module="dealer4dealer_xcore">
-                    <partially_updated_tierprices>
-                        <code>300</code>
-                        <message>Could not update all</message>
-                    </partially_updated_tierprices>
                     <invalid_data>
                         <code>301</code>
                         <message>Invalid data</message>
                     </invalid_data>
+                    <partially_updated_tierprices>
+                        <code>300</code>
+                        <message>Could not update all</message>
+                    </partially_updated_tierprices>
                 </faults>
             </xcore_catalog_product_attribute>
             <xcore_catalog_product_attribute_set module="dealer4dealer_xcore">
-                <model>dealer4dealer_xcore/catalog_product_attribute_set_api</model>
                 <title>Product Attribute Sets</title>
+                <model>dealer4dealer_xcore/catalog_product_attribute_set_api</model>
                 <methods>
-                    <groupInfo translate="title" module="dealer4dealer_xcore">
-                        <title>Get the information about a attribute set group</title>
+                    <groupInfo module="dealer4dealer_xcore" translate="title">
                         <acl>catalog/product/attribute/set</acl>
+                        <title>Get the information about a attribute set group</title>
                     </groupInfo>
                 </methods>
                 <faults module="dealer4dealer_xcore">
@@ -68,36 +57,78 @@
                     </not_found>
                 </faults>
             </xcore_catalog_product_attribute_set>
-            <xcore_customer translate="title" module="dealer4dealer_xcore">
-                <model>dealer4dealer_xcore/customer_api</model>
-                <title>Customers</title>
+            <xcore_custom>
+                <title>xCore Custom Attributes</title>
+                <model>dealer4dealer_xcore/custom_api</model>
                 <methods>
-                    <groupCreate translate="title" module="dealer4dealer_xcore">
-                        <title>Create customer group</title>
+                    <creditAttributes module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order</acl>
+                        <method>creditAttributes</method>
+                        <title>Custom Credit Attributes</title>
+                    </creditAttributes>
+                    <customerAttributes module="dealer4dealer_xcore" translate="title">
+                        <acl>customer/info</acl>
+                        <method>customerAttributes</method>
+                        <title>Custom Customer Attributes</title>
+                    </customerAttributes>
+                    <invoiceAttributes module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order</acl>
+                        <method>invoiceAttributes</method>
+                        <title>Custom Invoice Attributes</title>
+                    </invoiceAttributes>
+                    <itemAttributes module="dealer4dealer_xcore" translate="title">
+                        <acl>catalog/product/info</acl>
+                        <method>itemAttributes</method>
+                        <title>Custom Item Attributes</title>
+                    </itemAttributes>
+                    <saleAttributes module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order</acl>
+                        <method>saleAttributes</method>
+                        <title>Custom Sale Attributes</title>
+                    </saleAttributes>
+                </methods>
+            </xcore_custom>
+            <xcore_customer module="dealer4dealer_xcore" translate="title">
+                <title>Customers</title>
+                <model>dealer4dealer_xcore/customer_api</model>
+                <methods>
+                    <groupCreate module="dealer4dealer_xcore" translate="title">
                         <acl>customer/update</acl>
+                        <title>Create customer group</title>
                     </groupCreate>
                 </methods>
                 <faults module="dealer4dealer_xcore">
-                    <tax_classes_not_found>
-                        <code>500</code>
-                        <message>Requested tax classes not found.</message>
-                    </tax_classes_not_found>
                     <customer_group_not_created>
                         <code>501</code>
                         <message>Customer group not created.</message>
                     </customer_group_not_created>
+                    <tax_classes_not_found>
+                        <code>500</code>
+                        <message>Requested tax classes not found.</message>
+                    </tax_classes_not_found>
                 </faults>
             </xcore_customer>
-            <xcore_index translate="title" module="dealer4dealer_xcore">
-                <model>dealer4dealer_xcore/index_api</model>
-                <title>Indexes</title>
+            <xcore_customer_customer module="dealer4dealer_xcore" translate="title">
+                <title>Customers by limit</title>
+                <model>dealer4dealer_xcore/customer_customer_api</model>
                 <methods>
-                    <reindexAll translate="title" module="dealer4dealer_xcore">
-                        <title>Reindex all indexes</title>
-                    </reindexAll>
-                    <reindex translate="title" module="dealer4dealer_xcore">
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>customer/customer/info</acl>
+                        <method>items</method>
+                        <title>Retrieve customers by filters and limit</title>
+                    </list>
+                </methods>
+            </xcore_customer_customer>
+            <xcore_index module="dealer4dealer_xcore" translate="title">
+                <title>Indexes</title>
+                <model>dealer4dealer_xcore/index_api</model>
+                <methods>
+                    <reindex module="dealer4dealer_xcore" translate="title">
                         <title>Reindex specific index</title>
                     </reindex>
+                    <reindexAll module="dealer4dealer_xcore" translate="title">
+                        <title>Reindex all indexes</title>
+                    </reindexAll>
                 </methods>
                 <faults module="dealer4dealer_xcore">
                     <reindex_all_failed>
@@ -111,123 +142,127 @@
                 </faults>
             </xcore_index>
             <xcore_payment_method>
-                <model>dealer4dealer_xcore/payment_method_api</model>
                 <title>Payment Methods</title>
+                <model>dealer4dealer_xcore/payment_method_api</model>
                 <methods>
-                    <list translate="title" module="dealer4dealer_xcore">
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order</acl>
                         <method>info</method>
                         <title>Get a list of payment methods</title>
-                        <acl>sales/order</acl>
                     </list>
                 </methods>
             </xcore_payment_method>
-            <xcore_shipping_method>
-                <model>dealer4dealer_xcore/shipping_method_api</model>
-                <title>Shipping Methods</title>
-                <methods>
-                    <list translate="title" module="dealer4dealer_xcore">
-                        <method>info</method>
-                        <title>Get a list of shipping methods</title>
-                        <acl>sales/order</acl>
-                    </list>
-                </methods>
-            </xcore_shipping_method>
-            <xcore_version>
-                <model>dealer4dealer_xcore/version_api</model>
-                <title>xCore version</title>
-                <methods>
-                    <info translate="title" module="dealer4dealer_xcore">
-                        <method>info</method>
-                        <title>xCore version</title>
-                        <acl>core/store/info</acl>
-                    </info>
-                </methods>
-            </xcore_version>
-            <xcore_custom>
-                <model>dealer4dealer_xcore/custom_api</model>
-                <title>xCore Custom Attributes</title>
-                <methods>
-                    <itemAttributes translate="title" module="dealer4dealer_xcore">
-                        <method>itemAttributes</method>
-                        <title>Custom Item Attributes</title>
-                        <acl>catalog/product/info</acl>
-                    </itemAttributes>
-                    <customerAttributes translate="title" module="dealer4dealer_xcore">
-                        <method>customerAttributes</method>
-                        <title>Custom Customer Attributes</title>
-                        <acl>customer/info</acl>
-                    </customerAttributes>
-                    <saleAttributes translate="title" module="dealer4dealer_xcore">
-                        <method>saleAttributes</method>
-                        <title>Custom Sale Attributes</title>
-                        <acl>sales/order</acl>
-                    </saleAttributes>
-                    <invoiceAttributes translate="title" module="dealer4dealer_xcore">
-                        <method>invoiceAttributes</method>
-                        <title>Custom Invoice Attributes</title>
-                        <acl>sales/order</acl>
-                    </invoiceAttributes>
-                    <creditAttributes translate="title" module="dealer4dealer_xcore">
-                        <method>creditAttributes</method>
-                        <title>Custom Credit Attributes</title>
-                        <acl>sales/order</acl>
-                    </creditAttributes>
-                </methods>
-            </xcore_custom>
-            <xcore_website>
-                <model>dealer4dealer_xcore/website_api</model>
-                <title>Websites</title>
-                <methods>
-                    <items translate="title" module="dealer4dealer_xcore">
-                        <method>items</method>
-                        <title>List of websites</title>
-                        <acl>core/store/info</acl>
-                    </items>
-                </methods>
-            </xcore_website>
             <xcore_sales_order>
-                <model>dealer4dealer_xcore/sales_order_api</model>
                 <title>Sales Order</title>
+                <model>dealer4dealer_xcore/sales_order_api</model>
                 <methods>
-                    <states translate="title" module="dealer4dealer_xcore">
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order/info</acl>
+                        <method>items</method>
+                        <title>Retrieve list of orders by filters and limit</title>
+                    </list>
+                    <states module="dealer4dealer_xcore" translate="title">
+                        <acl>core/store/info</acl>
                         <method>states</method>
                         <title>List of sales order states</title>
-                        <acl>core/store/info</acl>
                     </states>
-                    <statuses translate="title" module="dealer4dealer_xcore">
+                    <statuses module="dealer4dealer_xcore" translate="title">
+                        <acl>core/store/info</acl>
                         <method>statuses</method>
                         <title>List of sales order statuses</title>
-                        <acl>core/store/info</acl>
                     </statuses>
                 </methods>
             </xcore_sales_order>
-            <xcore_sales_order_shipment>
-                <model>dealer4dealer_xcore/sales_order_shipment_api</model>
-                <title>Sales Order Shipment</title>
+            <xcore_sales_order_creditmemo>
+                <title>Sales Order Creditmemo</title>
+                <model>dealer4dealer_xcore/sales_order_creditmemo_api</model>
                 <methods>
-                    <xcoreCreate translate="title" module="sales">
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order/creditmemo/list</acl>
+                        <method>items</method>
+                        <title>Retrieve list of credit memos by filters and limit</title>
+                    </list>
+                </methods>
+            </xcore_sales_order_creditmemo>
+            <xcore_sales_order_shipment>
+                <title>Sales Order Shipment</title>
+                <model>dealer4dealer_xcore/sales_order_shipment_api</model>
+                <methods>
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order/shipment/list</acl>
+                        <method>items</method>
+                        <title>Retrieve list of shipments by filters and limit</title>
+                    </list>
+                    <xcoreCreate module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order/shipment/create</acl>
                         <title>Create new shipment for order with xcore_your_ref</title>
-                        <acl>sales/order/shipment</acl>
                     </xcoreCreate>
                 </methods>
             </xcore_sales_order_shipment>
+            <xcore_shipping_method>
+                <title>Shipping Methods</title>
+                <model>dealer4dealer_xcore/shipping_method_api</model>
+                <methods>
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>sales/order</acl>
+                        <method>info</method>
+                        <title>Get a list of shipping methods</title>
+                    </list>
+                </methods>
+            </xcore_shipping_method>
+            <xcore_tax_class_product>
+                <title>Product Tax Classes</title>
+                <model>dealer4dealer_xcore/tax_class_product_api</model>
+                <methods>
+                    <list module="dealer4dealer_xcore" translate="title">
+                        <acl>catalog/product/info</acl>
+                        <method>items</method>
+                        <title>Retrieve a list of product tax classes</title>
+                    </list>
+                </methods>
+            </xcore_tax_class_product>
+            <xcore_version>
+                <title>xCore version</title>
+                <model>dealer4dealer_xcore/version_api</model>
+                <methods>
+                    <info module="dealer4dealer_xcore" translate="title">
+                        <acl>core/store/info</acl>
+                        <method>info</method>
+                        <title>xCore version</title>
+                    </info>
+                </methods>
+            </xcore_version>
+            <xcore_website>
+                <title>Websites</title>
+                <model>dealer4dealer_xcore/website_api</model>
+                <methods>
+                    <items module="dealer4dealer_xcore" translate="title">
+                        <acl>core/store/info</acl>
+                        <method>items</method>
+                        <title>List of websites</title>
+                    </items>
+                </methods>
+            </xcore_website>
         </resources>
         <v2>
             <resources_function_prefix>
                 <xcore_catalog_product>xcoreCatalogProduct</xcore_catalog_product>
-                <xcore_tax_class_product>xcoreTaxClassProduct</xcore_tax_class_product>
                 <xcore_catalog_product_attribute>xcoreCatalogProductAttribute</xcore_catalog_product_attribute>
-                <xcore_customer>xcoreCustomer</xcore_customer>
-                <xcore_index>xcoreIndex</xcore_index>
+                <xcore_catalog_product_attribute_set>xcoreCatalogProductAttributeSet
+                </xcore_catalog_product_attribute_set>
                 <xcore_config>xcoreConfig</xcore_config>
-                <xcore_catalog_product_attribute_set>xcoreCatalogProductAttributeSet</xcore_catalog_product_attribute_set>
-                <xcore_payment_method>xcorePaymentMethod</xcore_payment_method>
-                <xcore_shipping_method>xcoreShippingMethod</xcore_shipping_method>
-                <xcore_version>xcoreVersion</xcore_version>
                 <xcore_custom>xcoreCustom</xcore_custom>
-                <xcore_website>xcoreWebsite</xcore_website>
+                <xcore_customer>xcoreCustomer</xcore_customer>
+                <xcore_customer_customer>xcoreCustomerCustomer</xcore_customer_customer>
+                <xcore_index>xcoreIndex</xcore_index>
+                <xcore_payment_method>xcorePaymentMethod</xcore_payment_method>
                 <xcore_sales_order>xcoreSalesOrder</xcore_sales_order>
+                <xcore_sales_order_creditmemo>xcoreSalesOrderCreditmemo</xcore_sales_order_creditmemo>
                 <xcore_sales_order_shipment>xcoreSalesOrderShipment</xcore_sales_order_shipment>
+                <xcore_shipping_method>xcoreShippingMethod</xcore_shipping_method>
+                <xcore_tax_class_product>xcoreTaxClassProduct</xcore_tax_class_product>
+                <xcore_version>xcoreVersion</xcore_version>
+                <xcore_website>xcoreWebsite</xcore_website>
             </resources_function_prefix>
         </v2>
     </api>

--- a/app/code/local/Dealer4dealer/Xcore/etc/config.xml
+++ b/app/code/local/Dealer4dealer/Xcore/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <dealer4dealer_xcore>
-            <version>1.6.0</version>
+            <version>1.7.0</version>
         </dealer4dealer_xcore>
     </modules>
     <global>
@@ -36,6 +36,7 @@
             </sales>
             <customer>
                 <rewrite>
+                    <api_v2>Dealer4dealer_Xcore_Model_Customer_Api_V2</api_v2>
                     <customer_api_v2>Dealer4dealer_Xcore_Model_Customer_Customer_Api_V2</customer_api_v2>
                 </rewrite>
             </customer>

--- a/app/code/local/Dealer4dealer/Xcore/etc/wsdl.xml
+++ b/app/code/local/Dealer4dealer/Xcore/etc/wsdl.xml
@@ -1,20 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-             xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             xmlns="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+<?xml version="1.0" encoding="utf-8"?>
+<definitions name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:typens="urn:{{var wsdl.name}}" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
-                    schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
-            <!-- Bugfix for Magento 1.6 -->
-            <complexType name="associativeMultiEntity">
-                <all>
-                    <element name="key" type="xsd:string"/>
-                    <element name="value" type="typens:ArrayOfString"/>
-                </all>
-            </complexType>
+        <schema targetNamespace="urn:Magento" xmlns="http://www.w3.org/2001/XMLSchema">
             <complexType name="associativeMultiArray">
                 <complexContent>
                     <restriction base="soapenc:Array">
@@ -22,111 +9,34 @@
                     </restriction>
                 </complexContent>
             </complexType>
-            <!-- Extra fields for existing calls -->
+            <complexType name="associativeMultiEntity">
+                <all>
+                    <element name="key" type="xsd:string"/>
+                    <element name="value" type="typens:ArrayOfString"/>
+                </all>
+            </complexType>
             <complexType name="catalogProductEntity">
                 <all>
-                    <element name="updated_at" type="xsd:string" minOccurs="0"/>
-                    <element name="created_at" type="xsd:string" minOccurs="0"/>
+                    <element minOccurs="0" name="created_at" type="xsd:string"/>
+                    <element minOccurs="0" name="updated_at" type="xsd:string"/>
                 </all>
             </complexType>
             <complexType name="catalogProductReturnEntity">
                 <all>
-                    <element name="tax_rate" type="xsd:float" minOccurs="0"/>
-                    <element name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="salesOrderEntity">
-                <all>
-                    <element name="xcore_base_shipping_discount_amount" type="xsd:string" minOccurs="0" />
-                    <element name="xcore_shipping_discount_amount" type="xsd:string" minOccurs="0" />
-                    <element name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" minOccurs="0" />
-                    <element name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="salesOrderShipmentEntity">
-                <all>
-                    <element name="xcore_your_ref" type="xsd:string" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="salesOrderInvoiceEntity">
-                <all>
-                    <element name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="salesOrderCreditmemoEntity">
-                <all>
-                    <element name="xcore_base_shipping_discount_amount" type="xsd:string" minOccurs="0" />
-                    <element name="xcore_shipping_discount_amount" type="xsd:string" minOccurs="0" />
-                    <element name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" minOccurs="0" />
-                    <element name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="customerCustomerEntity">
-                <all>
-                    <element name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="customerAddressEntityItem">
-                <all>
-                    <element name="vat_id" type="xsd:string" minOccurs="0" />
-                </all>
-            </complexType>
-            <complexType name="salesOrderAddressEntity">
-                <all>
-                    <element name="prefix" type="xsd:string" minOccurs="0" />
-                    <element name="suffix" type="xsd:string" minOccurs="0" />
-                    <element name="vat_id" type="xsd:string" minOccurs="0" />
-                </all>
-            </complexType>
-            <!-- Custom calls -->
-            <complexType name="xcoreSalesOrderPaymentFeeArray">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreSalesOrderPaymentFee[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreSalesOrderPaymentFee">
-                <all>
-                    <element name="base_amount" type="xsd:double" minOccurs="1" />
-                    <element name="amount" type="xsd:double" minOccurs="1" />
-                    <element name="tax_rate" type="xsd:double" minOccurs="1" />
-                    <element name="title" type="xsd:string" minOccurs="1" />
-                </all>
-            </complexType>
-            <complexType name="xcoreCatalogProductUpdateTierArray">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCatalogProductUpdateTierEntity[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreCatalogProductUpdateTierEntity">
-                <all>
-                    <element name="sku" type="xsd:string" />
-                    <element name="tierPrices" type="typens:xcoreCatalogProductTierPriceEntityArray" minOccurs="0"/>
-                </all>
-            </complexType>
-            <complexType name="xcoreCatalogProductTierPriceEntityArray">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCatalogProductTierPriceEntity[]"/>
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreCatalogProductTierPriceEntity">
-                <all>
-                    <element name="all_groups" type="xsd:int" minOccurs="0"/>
-                    <element name="customer_group_id" type="xsd:string" minOccurs="0"/>
-                    <element name="qty" type="xsd:int" minOccurs="0"/>
-                    <element name="price" type="xsd:double" minOccurs="0"/>
-                    <element name="website_id" type="xsd:string" minOccurs="0"/>
+                    <element minOccurs="0" name="tax_rate" type="xsd:float"/>
+                    <element minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray"/>
                 </all>
             </complexType>
             <complexType name="catalogProductUpdateTierResult">
                 <all>
                     <element name="success" type="typens:ArrayOfString"/>
                     <element name="error" type="typens:catalogProductUpdateTierResultFaultsArray"/>
+                </all>
+            </complexType>
+            <complexType name="catalogProductUpdateTierResultFaultEntity">
+                <all>
+                    <element name="sku" type="xsd:string"/>
+                    <element name="message" type="xsd:string"/>
                 </all>
             </complexType>
             <complexType name="catalogProductUpdateTierResultFaultsArray">
@@ -136,95 +46,196 @@
                     </restriction>
                 </complexContent>
             </complexType>
-            <complexType name="catalogProductUpdateTierResultFaultEntity">
+            <complexType name="customerAddressEntityItem">
+                <all>
+                    <element minOccurs="0" name="vat_id" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="customerCustomerEntity">
+                <all>
+                    <element minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray"/>
+                </all>
+            </complexType>
+            <complexType name="salesOrderAddressEntity">
+                <all>
+                    <element minOccurs="0" name="prefix" type="xsd:string"/>
+                    <element minOccurs="0" name="suffix" type="xsd:string"/>
+                    <element minOccurs="0" name="vat_id" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="salesOrderCreditmemoEntity">
+                <all>
+                    <element minOccurs="0" name="xcore_base_shipping_discount_amount" type="xsd:string"/>
+                    <element minOccurs="0" name="xcore_shipping_discount_amount" type="xsd:string"/>
+                    <element minOccurs="0" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray"/>
+                    <element minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray"/>
+                </all>
+            </complexType>
+            <complexType name="salesOrderEntity">
+                <all>
+                    <element minOccurs="0" name="xcore_base_shipping_discount_amount" type="xsd:string"/>
+                    <element minOccurs="0" name="xcore_shipping_discount_amount" type="xsd:string"/>
+                    <element minOccurs="0" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray"/>
+                    <element minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray"/>
+                </all>
+            </complexType>
+            <complexType name="salesOrderInvoiceEntity">
+                <all>
+                    <element minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray"/>
+                </all>
+            </complexType>
+            <complexType name="salesOrderShipmentEntity">
+                <all>
+                    <element minOccurs="0" name="xcore_your_ref" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreCatalogProductTierPriceEntity">
+                <all>
+                    <element minOccurs="0" name="all_groups" type="xsd:int"/>
+                    <element minOccurs="0" name="customer_group_id" type="xsd:string"/>
+                    <element minOccurs="0" name="qty" type="xsd:int"/>
+                    <element minOccurs="0" name="price" type="xsd:double"/>
+                    <element minOccurs="0" name="website_id" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreCatalogProductTierPriceEntityArray">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCatalogProductTierPriceEntity[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreCatalogProductUpdateTierArray">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCatalogProductUpdateTierEntity[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreCatalogProductUpdateTierEntity">
                 <all>
                     <element name="sku" type="xsd:string"/>
-                    <element name="message" type="xsd:string"/>
+                    <element minOccurs="0" name="tierPrices" type="typens:xcoreCatalogProductTierPriceEntityArray"/>
                 </all>
             </complexType>
-            <complexType name="xcoreTaxClassProductListResult">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreTaxClassProductListEntity[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreTaxClassProductListEntity">
+            <complexType name="xcoreCustomAttribute">
                 <all>
-                    <element name="tax_class_id" type="xsd:int" minOccurs="1" />
-                    <element name="label" type="xsd:string" minOccurs="1" />
-                </all>
-            </complexType>
-            <complexType name="xcorePaymentMethodListResult">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcorePaymentMethodEntity[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreShippingMethodListResult">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreShippingMethodEntity[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcoreSalesOrderStatesResult">
-                <complexContent>
-                    <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreSalesOrderStatesEntity[]" />
-                    </restriction>
-                </complexContent>
-            </complexType>
-            <complexType name="xcorePaymentMethodEntity">
-                <all>
-                    <element name="code" type="xsd:string" minOccurs="1" />
-                    <element name="label" type="xsd:string" minOccurs="1" />
-                </all>
-            </complexType>
-            <complexType name="xcoreShippingMethodEntity">
-                <all>
-                    <element name="code" type="xsd:string" minOccurs="1" />
-                    <element name="label" type="xsd:string" minOccurs="1" />
-                </all>
-            </complexType>
-            <complexType name="xcoreSalesOrderStatesEntity">
-                <all>
-                    <element name="key" type="xsd:string" minOccurs="1" />
-                    <element name="value" type="xsd:string" minOccurs="1" />
+                    <element minOccurs="1" name="key" type="xsd:string"/>
+                    <element minOccurs="1" name="value" type="xsd:string"/>
                 </all>
             </complexType>
             <complexType name="xcoreCustomAttributeArray">
                 <complexContent>
                     <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCustomAttribute[]" />
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreCustomAttribute[]"/>
                     </restriction>
                 </complexContent>
             </complexType>
-            <complexType name="xcoreCustomAttribute">
+            <complexType name="xcorePaymentMethodEntity">
                 <all>
-                    <element name="key" type="xsd:string" minOccurs="1" />
-                    <element name="value" type="xsd:string" minOccurs="1" />
+                    <element minOccurs="1" name="code" type="xsd:string"/>
+                    <element minOccurs="1" name="label" type="xsd:string"/>
                 </all>
             </complexType>
-            <complexType name="xcoreWebsiteItemsArray">
+            <complexType name="xcorePaymentMethodListResult">
                 <complexContent>
                     <restriction base="soapenc:Array">
-                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreWebsiteItem[]" />
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcorePaymentMethodEntity[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreSalesOrderPaymentFee">
+                <all>
+                    <element minOccurs="1" name="base_amount" type="xsd:double"/>
+                    <element minOccurs="1" name="amount" type="xsd:double"/>
+                    <element minOccurs="1" name="tax_rate" type="xsd:double"/>
+                    <element minOccurs="1" name="title" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreSalesOrderPaymentFeeArray">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreSalesOrderPaymentFee[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreSalesOrderStatesEntity">
+                <all>
+                    <element minOccurs="1" name="key" type="xsd:string"/>
+                    <element minOccurs="1" name="value" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreSalesOrderStatesResult">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreSalesOrderStatesEntity[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreShippingMethodEntity">
+                <all>
+                    <element minOccurs="1" name="code" type="xsd:string"/>
+                    <element minOccurs="1" name="label" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreShippingMethodListResult">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreShippingMethodEntity[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <complexType name="xcoreTaxClassProductListEntity">
+                <all>
+                    <element minOccurs="1" name="tax_class_id" type="xsd:int"/>
+                    <element minOccurs="1" name="label" type="xsd:string"/>
+                </all>
+            </complexType>
+            <complexType name="xcoreTaxClassProductListResult">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreTaxClassProductListEntity[]"/>
                     </restriction>
                 </complexContent>
             </complexType>
             <complexType name="xcoreWebsiteItem">
                 <all>
-                    <element name="website_id" type="xsd:string" minOccurs="1" />
-                    <element name="code" type="xsd:string" minOccurs="1" />
-                    <element name="name" type="xsd:string" minOccurs="1" />
-                    <element name="sort_order" type="xsd:string" minOccurs="1" />
-                    <element name="default_group_id" type="xsd:string" minOccurs="1" />
+                    <element minOccurs="1" name="website_id" type="xsd:string"/>
+                    <element minOccurs="1" name="code" type="xsd:string"/>
+                    <element minOccurs="1" name="name" type="xsd:string"/>
+                    <element minOccurs="1" name="sort_order" type="xsd:string"/>
+                    <element minOccurs="1" name="default_group_id" type="xsd:string"/>
                 </all>
             </complexType>
+            <complexType name="xcoreWebsiteItemsArray">
+                <complexContent>
+                    <restriction base="soapenc:Array">
+                        <attribute ref="soapenc:arrayType" wsdl:arrayType="typens:xcoreWebsiteItem[]"/>
+                    </restriction>
+                </complexContent>
+            </complexType>
+            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
         </schema>
     </types>
+    <message name="xcoreCatalogProductAttributeSetGroupInfoRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="attributeSetId" type="xsd:int"/>
+        <part name="groupName" type="xsd:string"/>
+    </message>
+    <message name="xcoreCatalogProductAttributeSetGroupInfoResponse">
+        <part name="attribute_group_id" type="xsd:int"/>
+        <part name="attribute_set_id" type="xsd:int"/>
+        <part name="attribute_group_name" type="xsd:string"/>
+        <part name="sort_order" type="xsd:int"/>
+        <part name="default_id" type="xsd:int"/>
+    </message>
+    <message name="xcoreCatalogProductAttributeTierPriceCreateRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="tierprices" type="typens:xcoreCatalogProductUpdateTierArray"/>
+    </message>
+    <message name="xcoreCatalogProductAttributeTierPriceCreateResponse">
+        <part name="result" type="typens:catalogProductUpdatePriceResult"/>
+    </message>
     <message name="xcoreCatalogProductListRequest">
         <part name="sessionId" type="xsd:string"/>
         <part name="filters" type="typens:filters"/>
@@ -234,36 +245,25 @@
     <message name="xcoreCatalogProductListResponse">
         <part name="storeView" type="typens:catalogProductEntityArray"/>
     </message>
-    <message name="xcoreCatalogProductAttributeTierPriceCreateRequest">
-        <part name="sessionId" type="xsd:string"/>
-        <part name="tierprices" type="typens:xcoreCatalogProductUpdateTierArray"/>
-    </message>
-    <message name="xcoreCatalogProductAttributeTierPriceCreateResponse">
-        <part name="result" type="typens:catalogProductUpdatePriceResult"/>
-    </message>
-    <message name="xcoreSalesOrderShipmentXcoreCreateRequest">
-        <part name="sessionId" type="xsd:string" />
-        <part name="orderIncrementId" type="xsd:string" />
-        <part name="itemsQty" type="typens:orderItemIdQtyArray" />
-        <part name="comment" type="xsd:string" />
-        <part name="email" type="xsd:int" />
-        <part name="includeComment" type="xsd:int" />
-        <part name="xcoreYourRef" type="xsd:string" />
-    </message>
-    <message name="xcoreSalesOrderShipmentXcoreCreateResponse">
-        <part name="shipmentIncrementId" type="xsd:string" />
-    </message>
-    <message name="xcoreTaxClassProductListRequest">
+    <message name="xcoreCustomCreditAttributesRequest">
         <part name="sessionId" type="xsd:string"/>
     </message>
-    <message name="xcoreTaxClassProductListResponse">
-        <part name="result" type="typens:xcoreTaxClassProductListResult"/>
+    <message name="xcoreCustomCreditAttributesResponse">
+        <part name="result" type="typens:xcoreCustomAttributeArray"/>
     </message>
-    <message name="xcoreCustomerTaxClassesListRequest">
+    <message name="xcoreCustomCustomerAttributesRequest">
         <part name="sessionId" type="xsd:string"/>
     </message>
-    <message name="xcoreCustomerTaxClassesListResponse">
-        <part name="taxclasses" type="typens:fieldArray"/>
+    <message name="xcoreCustomCustomerAttributesResponse">
+        <part name="result" type="typens:xcoreCustomAttributeArray"/>
+    </message>
+    <message name="xcoreCustomerCustomerListRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="filters" type="typens:filters"/>
+        <part name="limit" type="xsd:string"/>
+    </message>
+    <message name="xcoreCustomerCustomerListResponse">
+        <part name="result" type="typens:customerCustomerEntityArray"/>
     </message>
     <message name="xcoreCustomerGroupCreateRequest">
         <part name="sessionId" type="xsd:string"/>
@@ -272,6 +272,30 @@
     </message>
     <message name="xcoreCustomerGroupCreateResponse">
         <part name="xcoreerGroups" type="typens:fieldArray"/>
+    </message>
+    <message name="xcoreCustomerTaxClassesListRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreCustomerTaxClassesListResponse">
+        <part name="taxclasses" type="typens:fieldArray"/>
+    </message>
+    <message name="xcoreCustomInvoiceAttributesRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreCustomInvoiceAttributesResponse">
+        <part name="result" type="typens:xcoreCustomAttributeArray"/>
+    </message>
+    <message name="xcoreCustomItemAttributesRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreCustomItemAttributesResponse">
+        <part name="result" type="typens:xcoreCustomAttributeArray"/>
+    </message>
+    <message name="xcoreCustomSaleAttributesRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreCustomSaleAttributesResponse">
+        <part name="result" type="typens:xcoreCustomAttributeArray"/>
     </message>
     <message name="xcoreIndexReindexAllRequest">
         <part name="sessionId" type="xsd:string"/>
@@ -286,168 +310,188 @@
     <message name="xcoreIndexReindexResponse">
         <part name="taxclasses" type="typens:boolean"/>
     </message>
-    <message name="xcoreCatalogProductAttributeSetGroupInfoRequest">
-        <part name="sessionId" type="xsd:string" />
-        <part name="attributeSetId" type="xsd:int" />
-        <part name="groupName" type="xsd:string" />
-    </message>
-    <message name="xcoreCatalogProductAttributeSetGroupInfoResponse">
-        <part name="attribute_group_id" type="xsd:int" />
-        <part name="attribute_set_id" type="xsd:int" />
-        <part name="attribute_group_name" type="xsd:string" />
-        <part name="sort_order" type="xsd:int" />
-        <part name="default_id" type="xsd:int" />
-    </message>
     <message name="xcorePaymentMethodListRequest">
-        <part name="sessionId" type="xsd:string" />
+        <part name="sessionId" type="xsd:string"/>
     </message>
     <message name="xcorePaymentMethodListResponse">
-        <part name="result" type="typens:xcorePaymentMethodListResult" />
+        <part name="result" type="typens:xcorePaymentMethodListResult"/>
     </message>
-    <message name="xcoreShippingMethodListRequest">
-        <part name="sessionId" type="xsd:string" />
+    <message name="xcoreSalesOrderCreditmemoListRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="filters" type="typens:filters"/>
+        <part name="limit" type="xsd:string"/>
     </message>
-    <message name="xcoreShippingMethodListResponse">
-        <part name="result" type="typens:xcoreShippingMethodListResult" />
+    <message name="xcoreSalesOrderCreditmemoListResponse">
+        <part name="result" type="typens:salesOrderCreditmemoEntityArray"/>
+    </message>
+    <message name="xcoreSalesOrderListRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="filters" type="typens:filters"/>
+        <part name="limit" type="xsd:string"/>
+    </message>
+    <message name="xcoreSalesOrderListResponse">
+        <part name="result" type="typens:salesOrderListEntityArray"/>
+    </message>
+    <message name="xcoreSalesOrderShipmentListRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="filters" type="typens:filters"/>
+        <part name="limit" type="xsd:string"/>
+    </message>
+    <message name="xcoreSalesOrderShipmentListResponse">
+        <part name="result" type="typens:salesOrderShipmentEntityArray"/>
+    </message>
+    <message name="xcoreSalesOrderShipmentXcoreCreateRequest">
+        <part name="sessionId" type="xsd:string"/>
+        <part name="orderIncrementId" type="xsd:string"/>
+        <part name="itemsQty" type="typens:orderItemIdQtyArray"/>
+        <part name="comment" type="xsd:string"/>
+        <part name="email" type="xsd:int"/>
+        <part name="includeComment" type="xsd:int"/>
+        <part name="xcoreYourRef" type="xsd:string"/>
+    </message>
+    <message name="xcoreSalesOrderShipmentXcoreCreateResponse">
+        <part name="shipmentIncrementId" type="xsd:string"/>
     </message>
     <message name="xcoreSalesOrderStatesRequest">
-        <part name="sessionId" type="xsd:string" />
+        <part name="sessionId" type="xsd:string"/>
     </message>
     <message name="xcoreSalesOrderStatesResponse">
-        <part name="result" type="typens:xcoreSalesOrderStatesResult" />
+        <part name="result" type="typens:xcoreSalesOrderStatesResult"/>
+    </message>
+    <message name="xcoreShippingMethodListRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreShippingMethodListResponse">
+        <part name="result" type="typens:xcoreShippingMethodListResult"/>
+    </message>
+    <message name="xcoreTaxClassProductListRequest">
+        <part name="sessionId" type="xsd:string"/>
+    </message>
+    <message name="xcoreTaxClassProductListResponse">
+        <part name="result" type="typens:xcoreTaxClassProductListResult"/>
     </message>
     <message name="xcoreVersionInfoRequest">
-        <part name="sessionId" type="xsd:string" />
+        <part name="sessionId" type="xsd:string"/>
     </message>
     <message name="xcoreVersionInfoResponse">
-        <part name="version" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomItemAttributesRequest">
-        <part name="sessionId" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomItemAttributesResponse">
-        <part name="result" type="typens:xcoreCustomAttributeArray" />
-    </message>
-    <message name="xcoreCustomCustomerAttributesRequest">
-        <part name="sessionId" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomCustomerAttributesResponse">
-        <part name="result" type="typens:xcoreCustomAttributeArray" />
-    </message>
-    <message name="xcoreCustomSaleAttributesRequest">
-        <part name="sessionId" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomSaleAttributesResponse">
-        <part name="result" type="typens:xcoreCustomAttributeArray" />
-    </message>
-    <message name="xcoreCustomInvoiceAttributesRequest">
-        <part name="sessionId" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomInvoiceAttributesResponse">
-        <part name="result" type="typens:xcoreCustomAttributeArray" />
-    </message>
-    <message name="xcoreCustomCreditAttributesRequest">
-        <part name="sessionId" type="xsd:string" />
-    </message>
-    <message name="xcoreCustomCreditAttributesResponse">
-        <part name="result" type="typens:xcoreCustomAttributeArray" />
+        <part name="version" type="xsd:string"/>
     </message>
     <message name="xcoreWebsiteItemsRequest">
-        <part name="sessionId" type="xsd:string" />
+        <part name="sessionId" type="xsd:string"/>
     </message>
     <message name="xcoreWebsiteItemsResponse">
-        <part name="result" type="typens:xcoreWebsiteItemsArray" />
+        <part name="result" type="typens:xcoreWebsiteItemsArray"/>
     </message>
     <portType name="{{var wsdl.handler}}PortType">
-        <operation name="xcoreCatalogProductList">
-            <documentation>Retrieve products list by filters and limit</documentation>
-            <input message="typens:xcoreCatalogProductListRequest"/>
-            <output message="typens:xcoreCatalogProductListResponse"/>
+        <operation name="xcoreCatalogProductAttributeSetGroupInfo">
+            <documentation>Group Info</documentation>
+            <input message="typens:xcoreCatalogProductAttributeSetGroupInfoRequest"/>
+            <output message="typens:xcoreCatalogProductAttributeSetGroupInfoResponse"/>
         </operation>
         <operation name="xcoreCatalogProductAttributeTierPriceCreate">
             <documentation>Create tier prices</documentation>
             <input message="typens:xcoreCatalogProductAttributeTierPriceCreateRequest"/>
             <output message="typens:xcoreCatalogProductAttributeTierPriceCreateResponse"/>
         </operation>
-        <operation name="xcoreSalesOrderShipmentXcoreCreate">
-            <documentation>Create new shipment for order with xcore_your_ref</documentation>
-            <input message="typens:xcoreSalesOrderShipmentXcoreCreateRequest"/>
-            <output message="typens:xcoreSalesOrderShipmentXcoreCreateResponse"/>
+        <operation name="xcoreCatalogProductList">
+            <documentation>Retrieve products list by filters and limit</documentation>
+            <input message="typens:xcoreCatalogProductListRequest"/>
+            <output message="typens:xcoreCatalogProductListResponse"/>
         </operation>
-        <operation name="xcoreTaxClassProductList">
-            <documentation>Create tier prices</documentation>
-            <input message="typens:xcoreTaxClassProductListRequest"/>
-            <output message="typens:xcoreTaxClassProductListResponse"/>
-        </operation>
-        <operation name="xcoreCustomerTaxClassesList">
-            <documentation>List of product tax classes</documentation>
-            <input message="typens:xcoreCustomerTaxClassesListRequest"/>
-            <output message="typens:xcoreCustomerTaxClassesListResponse"/>
-        </operation>
-        <operation name="xcoreCustomerGroupCreate">
-            <documentation>List of product tax classes</documentation>
-            <input message="typens:xcoreCustomerGroupCreateRequest"/>
-            <output message="typens:xcoreCustomerGroupCreateResponse"/>
-        </operation>
-        <operation name="xcoreIndexReindexAll">
-            <documentation>Paged and sorted list of products</documentation>
-            <input message="typens:xcoreIndexReindexAllRequest"/>
-            <output message="typens:xcoreIndexReindexAllResponse"/>
-        </operation>
-        <operation name="xcoreIndexReindex">
-            <documentation>Paged and sorted list of products</documentation>
-            <input message="typens:xcoreIndexReindexRequest"/>
-            <output message="typens:xcoreIndexReindexResponse"/>
-        </operation>
-        <operation name="xcoreCatalogProductAttributeSetGroupInfo">
-            <documentation>Group Info</documentation>
-            <input message="typens:xcoreCatalogProductAttributeSetGroupInfoRequest"/>
-            <output message="typens:xcoreCatalogProductAttributeSetGroupInfoResponse"/>
-        </operation>
-        <operation name="xcorePaymentMethodList">
-            <documentation>Group Info</documentation>
-            <input message="typens:xcorePaymentMethodListRequest"/>
-            <output message="typens:xcorePaymentMethodListResponse"/>
-        </operation>
-        <operation name="xcoreShippingMethodList">
-            <documentation>Group Info</documentation>
-            <input message="typens:xcoreShippingMethodListRequest"/>
-            <output message="typens:xcoreShippingMethodListResponse"/>
-        </operation>
-        <operation name="xcoreSalesOrderStates">
-            <documentation>Group Info</documentation>
-            <input message="typens:xcoreSalesOrderStatesRequest"/>
-            <output message="typens:xcoreSalesOrderStatesResponse"/>
-        </operation>
-        <operation name="xcoreVersionInfo">
-            <documentation>Group Info</documentation>
-            <input message="typens:xcoreVersionInfoRequest"/>
-            <output message="typens:xcoreVersionInfoResponse"/>
-        </operation>
-        <operation name="xcoreCustomItemAttributes">
-            <documentation>List of custom xcore Item Attributes</documentation>
-            <input message="typens:xcoreCustomItemAttributesRequest"/>
-            <output message="typens:xcoreCustomItemAttributesResponse"/>
+        <operation name="xcoreCustomCreditAttributes">
+            <documentation>List of custom xcore Credit Attributes</documentation>
+            <input message="typens:xcoreCustomCreditAttributesRequest"/>
+            <output message="typens:xcoreCustomCreditAttributesResponse"/>
         </operation>
         <operation name="xcoreCustomCustomerAttributes">
             <documentation>List of custom xcore Customer Attributes</documentation>
             <input message="typens:xcoreCustomCustomerAttributesRequest"/>
             <output message="typens:xcoreCustomCustomerAttributesResponse"/>
         </operation>
-        <operation name="xcoreCustomSaleAttributes">
-            <documentation>List of custom xcore Sale Attributes</documentation>
-            <input message="typens:xcoreCustomSaleAttributesRequest"/>
-            <output message="typens:xcoreCustomSaleAttributesResponse"/>
+        <operation name="xcoreCustomerCustomerList">
+            <documentation>Retrieve customers by filters and limit</documentation>
+            <input message="typens:xcoreCustomerCustomerListRequest"/>
+            <output message="typens:xcoreCustomerCustomerListResponse"/>
+        </operation>
+        <operation name="xcoreCustomerGroupCreate">
+            <documentation>List of product tax classes</documentation>
+            <input message="typens:xcoreCustomerGroupCreateRequest"/>
+            <output message="typens:xcoreCustomerGroupCreateResponse"/>
+        </operation>
+        <operation name="xcoreCustomerTaxClassesList">
+            <documentation>List of product tax classes</documentation>
+            <input message="typens:xcoreCustomerTaxClassesListRequest"/>
+            <output message="typens:xcoreCustomerTaxClassesListResponse"/>
         </operation>
         <operation name="xcoreCustomInvoiceAttributes">
             <documentation>List of custom xcore Sale Attributes</documentation>
             <input message="typens:xcoreCustomInvoiceAttributesRequest"/>
             <output message="typens:xcoreCustomInvoiceAttributesResponse"/>
         </operation>
-        <operation name="xcoreCustomCreditAttributes">
-            <documentation>List of custom xcore Credit Attributes</documentation>
-            <input message="typens:xcoreCustomCreditAttributesRequest"/>
-            <output message="typens:xcoreCustomCreditAttributesResponse"/>
+        <operation name="xcoreCustomItemAttributes">
+            <documentation>List of custom xcore Item Attributes</documentation>
+            <input message="typens:xcoreCustomItemAttributesRequest"/>
+            <output message="typens:xcoreCustomItemAttributesResponse"/>
+        </operation>
+        <operation name="xcoreCustomSaleAttributes">
+            <documentation>List of custom xcore Sale Attributes</documentation>
+            <input message="typens:xcoreCustomSaleAttributesRequest"/>
+            <output message="typens:xcoreCustomSaleAttributesResponse"/>
+        </operation>
+        <operation name="xcoreIndexReindex">
+            <documentation>Paged and sorted list of products</documentation>
+            <input message="typens:xcoreIndexReindexRequest"/>
+            <output message="typens:xcoreIndexReindexResponse"/>
+        </operation>
+        <operation name="xcoreIndexReindexAll">
+            <documentation>Paged and sorted list of products</documentation>
+            <input message="typens:xcoreIndexReindexAllRequest"/>
+            <output message="typens:xcoreIndexReindexAllResponse"/>
+        </operation>
+        <operation name="xcorePaymentMethodList">
+            <documentation>Group Info</documentation>
+            <input message="typens:xcorePaymentMethodListRequest"/>
+            <output message="typens:xcorePaymentMethodListResponse"/>
+        </operation>
+        <operation name="xcoreSalesOrderCreditmemoList">
+            <documentation>Retrieve list of orders by filters and limit</documentation>
+            <input message="typens:xcoreSalesOrderCreditmemoListRequest"/>
+            <output message="typens:xcoreSalesOrderCreditmemoListResponse"/>
+        </operation>
+        <operation name="xcoreSalesOrderList">
+            <documentation>Retrieve list of orders by filters and limit</documentation>
+            <input message="typens:xcoreSalesOrderListRequest"/>
+            <output message="typens:xcoreSalesOrderListResponse"/>
+        </operation>
+        <operation name="xcoreSalesOrderShipmentList">
+            <documentation>Retrieve list of orders by filters and limit</documentation>
+            <input message="typens:xcoreSalesOrderShipmentListRequest"/>
+            <output message="typens:xcoreSalesOrderShipmentListResponse"/>
+        </operation>
+        <operation name="xcoreSalesOrderShipmentXcoreCreate">
+            <documentation>Create new shipment for order with xcore_your_ref</documentation>
+            <input message="typens:xcoreSalesOrderShipmentXcoreCreateRequest"/>
+            <output message="typens:xcoreSalesOrderShipmentXcoreCreateResponse"/>
+        </operation>
+        <operation name="xcoreSalesOrderStates">
+            <documentation>Group Info</documentation>
+            <input message="typens:xcoreSalesOrderStatesRequest"/>
+            <output message="typens:xcoreSalesOrderStatesResponse"/>
+        </operation>
+        <operation name="xcoreShippingMethodList">
+            <documentation>Group Info</documentation>
+            <input message="typens:xcoreShippingMethodListRequest"/>
+            <output message="typens:xcoreShippingMethodListResponse"/>
+        </operation>
+        <operation name="xcoreTaxClassProductList">
+            <documentation>Create tier prices</documentation>
+            <input message="typens:xcoreTaxClassProductListRequest"/>
+            <output message="typens:xcoreTaxClassProductListResponse"/>
+        </operation>
+        <operation name="xcoreVersionInfo">
+            <documentation>Group Info</documentation>
+            <input message="typens:xcoreVersionInfoRequest"/>
+            <output message="typens:xcoreVersionInfoResponse"/>
         </operation>
         <operation name="xcoreWebsiteItems">
             <documentation>List of websites</documentation>
@@ -457,175 +501,211 @@
     </portType>
     <binding name="{{var wsdl.handler}}Binding" type="typens:{{var wsdl.handler}}PortType">
         <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="xcoreCatalogProductList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+        <operation name="xcoreCatalogProductAttributeSetGroupInfo">
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </output>
         </operation>
         <operation name="xcoreCatalogProductAttributeTierPriceCreate">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </output>
         </operation>
-        <operation name="xcoreSalesOrderShipmentXcoreCreate">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+        <operation name="xcoreCatalogProductList">
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreTaxClassProductList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomerTaxClassesList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomerGroupCreate">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreIndexReindexAll">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreIndexReindex">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCatalogProductAttributeSetGroupInfo">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcorePaymentMethodList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreShippingMethodList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreSalesOrderStates">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreVersionInfo">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomItemAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomCustomerAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomSaleAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </output>
-        </operation>
-        <operation name="xcoreCustomInvoiceAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </input>
-            <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </output>
         </operation>
         <operation name="xcoreCustomCreditAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomCustomerAttributes">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomerCustomerList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomerGroupCreate">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomerTaxClassesList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomInvoiceAttributes">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomItemAttributes">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreCustomSaleAttributes">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreIndexReindex">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreIndexReindexAll">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcorePaymentMethodList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreSalesOrderCreditmemoList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreSalesOrderList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreSalesOrderShipmentList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreSalesOrderShipmentXcoreCreate">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreSalesOrderStates">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreShippingMethodList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreTaxClassProductList">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </output>
+        </operation>
+        <operation name="xcoreVersionInfo">
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
+            </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </output>
         </operation>
         <operation name="xcoreWebsiteItems">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded"/>
             </output>
         </operation>
     </binding>

--- a/app/code/local/Dealer4dealer/Xcore/etc/wsi.xml
+++ b/app/code/local/Dealer4dealer/Xcore/etc/wsi.xml
@@ -1,314 +1,203 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
-                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
-                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-                  name="{{var wsdl.name}}"
-                  targetNamespace="urn:{{var wsdl.name}}">
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="{{var wsdl.name}}" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="urn:{{var wsdl.name}}" xmlns:typens="urn:{{var wsdl.name}}" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
-
-            <!-- Extra fields for existing calls -->
-            <xsd:element name="catalogProductInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:catalogProductReturnEntity" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
+        <xsd:schema targetNamespace="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xsd:complexType name="catalogProductEntity">
                 <xsd:sequence>
-                    <xsd:element name="updated_at" type="xsd:string" minOccurs="0" />
-                    <xsd:element name="created_at" type="xsd:string" minOccurs="0" />
+                    <xsd:element minOccurs="0" name="created_at" type="xsd:string" />
+                    <xsd:element minOccurs="0" name="updated_at" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:complexType name="catalogProductReturnEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="tax_rate" type="xsd:float" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="tax_rate" type="xsd:float" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:element name="salesOrderInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:salesOrderEntity" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="salesOrderEntity">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_base_shipping_discount_amount" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_shipping_discount_amount" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:complexType name="salesOrderInvoiceEntity">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:element name="salesOrderCreditmemoInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:salesOrderCreditmemoEntity" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="salesOrderCreditmemoEntity">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_base_shipping_discount_amount" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_shipping_discount_amount" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:element name="customerCustomerInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="0" maxOccurs="1" name="result" type="typens:customerCustomerEntity" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="customerCustomerEntity">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:element name="customerAddressInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:customerAddressEntityItem" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
             <xsd:complexType name="customerAddressEntityItem">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="vat_id" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="vat_id" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="customerCustomerEntity">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:complexType name="salesOrderAddressEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="prefix" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="suffix" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="vat_id" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="prefix" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="suffix" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="vat_id" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
-
-            <!-- Custom calls -->
-            <xsd:complexType name="xcoreSalesOrderPaymentFeeArray">
+            <xsd:complexType name="salesOrderCreditmemoEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreSalesOrderPaymentFee" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_base_shipping_discount_amount" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_shipping_discount_amount" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:complexType name="xcoreSalesOrderPaymentFee">
+            <xsd:complexType name="salesOrderEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="1" maxOccurs="1" name="base_amount" type="xsd:double" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="amount" type="xsd:double" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="tax_rate" type="xsd:double" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="title" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_base_shipping_discount_amount" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_shipping_discount_amount" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_payment_fees" type="typens:xcoreSalesOrderPaymentFeeArray" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:element name="xcoreTaxClassProductListRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreTaxClassProductListResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreTaxClassProductListResult"/>
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="xcoreTaxClassProductListResult">
+            <xsd:complexType name="salesOrderInvoiceEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreTaxClassProductListEntity" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="xcore_custom_attributes" type="typens:xcoreCustomAttributeArray" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:complexType name="xcoreTaxClassProductListEntity">
+            <xsd:complexType name="xcoreCatalogProductAttributeSetGroupEntity">
                 <xsd:sequence>
-                    <xsd:element name="tax_class_id" type="xsd:int" minOccurs="1" />
-                    <xsd:element name="label" type="xsd:string" minOccurs="1" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="attribute_group_id" type="xsd:int" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="attribute_set_id" type="xsd:int" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="attribute_group_name" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="sort_order" type="xsd:int" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="default_id" type="xsd:int" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:element name="xcorePaymentMethodListRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreShippingMethodListRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreSalesOrderStatesRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcorePaymentMethodListResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcorePaymentMethodListResult" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreShippingMethodListResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreShippingMethodListResult" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreSalesOrderStatesResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreSalesOrderStatesResult" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="xcorePaymentMethodListResult">
+            <xsd:complexType name="xcoreCustomAttribute">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcorePaymentMethodEntity" />
+                    <xsd:element minOccurs="1" name="key" type="xsd:string" />
+                    <xsd:element minOccurs="1" name="value" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:complexType name="xcoreShippingMethodListResult">
+            <xsd:complexType name="xcoreCustomAttributeArray">
                 <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreShippingMethodEntity" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:complexType name="xcoreSalesOrderStatesResult">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreSalesOrderStateEntity" />
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreCustomAttribute" />
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:complexType name="xcorePaymentMethodEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="1" maxOccurs="1" name="code" type="xsd:string" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="label" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="code" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="label" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:complexType name="xcoreShippingMethodEntity">
+            <xsd:complexType name="xcorePaymentMethodListResult">
                 <xsd:sequence>
-                    <xsd:element minOccurs="1" maxOccurs="1" name="code" type="xsd:string" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="label" type="xsd:string" />
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcorePaymentMethodEntity" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreSalesOrderPaymentFee">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="base_amount" type="xsd:double" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="amount" type="xsd:double" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="tax_rate" type="xsd:double" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="title" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreSalesOrderPaymentFeeArray">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreSalesOrderPaymentFee" />
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:complexType name="xcoreSalesOrderStateEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="1" maxOccurs="1" name="key" type="xsd:string" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="value" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="key" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="value" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
+            <xsd:complexType name="xcoreSalesOrderStatesResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreSalesOrderStateEntity" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreShippingMethodEntity">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="code" type="xsd:string" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="label" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreShippingMethodListResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreShippingMethodEntity" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreTaxClassProductListEntity">
+                <xsd:sequence>
+                    <xsd:element minOccurs="1" name="tax_class_id" type="xsd:int" />
+                    <xsd:element minOccurs="1" name="label" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreTaxClassProductListResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreTaxClassProductListEntity" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreWebsiteItem">
+                <xsd:sequence>
+                    <xsd:element minOccurs="1" name="website_id" type="xsd:string" />
+                    <xsd:element minOccurs="1" name="code" type="xsd:string" />
+                    <xsd:element minOccurs="1" name="name" type="xsd:string" />
+                    <xsd:element minOccurs="1" name="sort_order" type="xsd:string" />
+                    <xsd:element minOccurs="1" name="default_group_id" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="xcoreWebsiteItemsArray">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="complexObjectArray" type="typens:xcoreWebsiteItem" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="catalogProductInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="typens:catalogProductReturnEntity" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="customerAddressInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="typens:customerAddressEntityItem" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="customerCustomerInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="0" name="result" type="typens:customerCustomerEntity" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="salesOrderCreditmemoInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="typens:salesOrderCreditmemoEntity" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="salesOrderInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="typens:salesOrderEntity" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
             <xsd:element name="xcoreCatalogProductAttributeSetGroupInfoRequestParam">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                        <xsd:element minOccurs="1" maxOccurs="1" name="attributeSetId" type="xsd:int" />
-                        <xsd:element minOccurs="1" maxOccurs="1" name="attributeSetGroupName" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="attributeSetId" type="xsd:int" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="attributeSetGroupName" type="xsd:string" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
             <xsd:element name="xcoreCatalogProductAttributeSetGroupInfoResponseParam">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:xcoreCatalogProductAttributeSetGroupEntity" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:complexType name="xcoreCatalogProductAttributeSetGroupEntity">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="1" name="attribute_group_id" type="xsd:int" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="attribute_set_id" type="xsd:int" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="attribute_group_name" type="xsd:string" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="sort_order" type="xsd:int" />
-                    <xsd:element minOccurs="0" maxOccurs="1" name="default_id" type="xsd:int" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:element name="xcoreVersionInfoRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreVersionInfoResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomItemAttributesRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomItemAttributesResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomCustomerAttributesRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomCustomerAttributesResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomSaleAttributesRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomSaleAttributesResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomInvoiceAttributesRequestParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
-                    </xsd:sequence>
-                </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="xcoreCustomInvoiceAttributesResponseParam">
-                <xsd:complexType>
-                    <xsd:sequence>
-                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="typens:xcoreCatalogProductAttributeSetGroupEntity" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
             <xsd:element name="xcoreCustomCreditAttributesRequestParam">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
@@ -319,21 +208,182 @@
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
-            <xsd:complexType name="xcoreCustomAttributeArray">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreCustomAttribute" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:complexType name="xcoreCustomAttribute">
-                <xsd:sequence>
-                    <xsd:element name="key" type="xsd:string" minOccurs="1" />
-                    <xsd:element name="value" type="xsd:string" minOccurs="1" />
-                </xsd:sequence>
-            </xsd:complexType>
+            <xsd:element name="xcoreCustomCustomerAttributesRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomCustomerAttributesResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomInvoiceAttributesRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomInvoiceAttributesResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomItemAttributesRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomItemAttributesResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomSaleAttributesRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreCustomSaleAttributesResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreCustomAttributeArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcorePaymentMethodListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcorePaymentMethodListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcorePaymentMethodListResult" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderCreditmemoListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="0" name="filters" type="typens:filters" />
+                        <xsd:element maxOccurs="1" minOccurs="0" name="limit" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderCreditmemoListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:salesOrderCreditmemoEntityArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="0" name="filters" type="typens:filters" />
+                        <xsd:element maxOccurs="1" minOccurs="0" name="limit" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:salesOrderListEntityArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderShipmentListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderShipmentListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:salesOrderShipmentEntityArray" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderStatesRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreSalesOrderStatesResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreSalesOrderStatesResult" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreShippingMethodListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreShippingMethodListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreShippingMethodListResult" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreTaxClassProductListRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreTaxClassProductListResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="typens:xcoreTaxClassProductListResult" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreVersionInfoRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="xcoreVersionInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element maxOccurs="1" minOccurs="1" name="result" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
             <xsd:element name="xcoreWebsiteItemsRequestParam">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="sessionId" type="xsd:string" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
@@ -344,274 +394,327 @@
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
-            <xsd:complexType name="xcoreWebsiteItemsArray">
-                <xsd:sequence>
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:xcoreWebsiteItem" />
-                </xsd:sequence>
-            </xsd:complexType>
-            <xsd:complexType name="xcoreWebsiteItem">
-                <xsd:sequence>
-                    <xsd:element name="website_id" type="xsd:string" minOccurs="1" />
-                    <xsd:element name="code" type="xsd:string" minOccurs="1" />
-                    <xsd:element name="name" type="xsd:string" minOccurs="1" />
-                    <xsd:element name="default_group_id" type="xsd:string" minOccurs="1" />
-                    <xsd:element name="is_default" type="xsd:string" minOccurs="1" />
-                </xsd:sequence>
-            </xsd:complexType>
         </xsd:schema>
     </wsdl:types>
-    <wsdl:message name="xcoreTaxClassProductListRequest">
-        <wsdl:part name="parameters" element="typens:xcoreTaxClassProductListRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreTaxClassProductListResponse">
-        <wsdl:part name="parameters" element="typens:xcoreTaxClassProductListResponseParam" />
-    </wsdl:message>
     <wsdl:message name="xcoreCatalogProductAttributeSetGroupInfoRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCatalogProductAttributeSetGroupInfoRequestParam" />
+        <wsdl:part element="typens:xcoreCatalogProductAttributeSetGroupInfoRequestParam" name="parameters" />
     </wsdl:message>
     <wsdl:message name="xcoreCatalogProductAttributeSetGroupInfoResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCatalogProductAttributeSetGroupInfoResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcorePaymentMethodListRequest">
-        <wsdl:part name="parameters" element="typens:xcorePaymentMethodListRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcorePaymentMethodListResponse">
-        <wsdl:part name="parameters" element="typens:xcorePaymentMethodListResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreShippingMethodListRequest">
-        <wsdl:part name="parameters" element="typens:xcoreShippingMethodListRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreShippingMethodListResponse">
-        <wsdl:part name="parameters" element="typens:xcoreShippingMethodListResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreSalesOrderStatesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreSalesOrderStatesRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreSalesOrderStatesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreSalesOrderStatesResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreVersionInfoRequest">
-        <wsdl:part name="parameters" element="typens:xcoreVersionInfoRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreVersionInfoResponse">
-        <wsdl:part name="parameters" element="typens:xcoreVersionInfoResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomItemAttributesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCustomItemAttributesRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomItemAttributesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCustomItemAttributesResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomCustomerAttributesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCustomCustomerAttributesRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomCustomerAttributesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCustomCustomerAttributesResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomSaleAttributesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCustomSaleAttributesRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomSaleAttributesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCustomSaleAttributesResponseParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomInvoiceAttributesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCustomInvoiceAttributesRequestParam" />
-    </wsdl:message>
-    <wsdl:message name="xcoreCustomInvoiceAttributesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCustomInvoiceAttributesResponseParam" />
+        <wsdl:part element="typens:xcoreCatalogProductAttributeSetGroupInfoResponseParam" name="parameters" />
     </wsdl:message>
     <wsdl:message name="xcoreCustomCreditAttributesRequest">
-        <wsdl:part name="parameters" element="typens:xcoreCustomCreditAttributesRequestParam" />
+        <wsdl:part element="typens:xcoreCustomCreditAttributesRequestParam" name="parameters" />
     </wsdl:message>
     <wsdl:message name="xcoreCustomCreditAttributesResponse">
-        <wsdl:part name="parameters" element="typens:xcoreCustomCreditAttributesResponseParam" />
+        <wsdl:part element="typens:xcoreCustomCreditAttributesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomCustomerAttributesRequest">
+        <wsdl:part element="typens:xcoreCustomCustomerAttributesRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomCustomerAttributesResponse">
+        <wsdl:part element="typens:xcoreCustomCustomerAttributesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomCustomerListRequest">
+        <wsdl:part element="typens:xcoreCustomCustomerListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomCustomerListResponse">
+        <wsdl:part element="typens:xcoreCustomCustomerListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomInvoiceAttributesRequest">
+        <wsdl:part element="typens:xcoreCustomInvoiceAttributesRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomInvoiceAttributesResponse">
+        <wsdl:part element="typens:xcoreCustomInvoiceAttributesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomItemAttributesRequest">
+        <wsdl:part element="typens:xcoreCustomItemAttributesRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomItemAttributesResponse">
+        <wsdl:part element="typens:xcoreCustomItemAttributesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomSaleAttributesRequest">
+        <wsdl:part element="typens:xcoreCustomSaleAttributesRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreCustomSaleAttributesResponse">
+        <wsdl:part element="typens:xcoreCustomSaleAttributesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcorePaymentMethodListRequest">
+        <wsdl:part element="typens:xcorePaymentMethodListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcorePaymentMethodListResponse">
+        <wsdl:part element="typens:xcorePaymentMethodListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderCreditmemoListRequest">
+        <wsdl:part element="typens:xcoreSalesOrderCreditmemoListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderCreditmemoListResponse">
+        <wsdl:part element="typens:xcoreSalesOrderCreditmemoListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderListRequest">
+        <wsdl:part element="typens:xcoreSalesOrderListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderListResponse">
+        <wsdl:part element="typens:xcoreSalesOrderListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderShipmentListRequest">
+        <wsdl:part element="typens:xcoreSalesOrderShipmentListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderShipmentListResponse">
+        <wsdl:part element="typens:xcoreSalesOrderShipmentListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderStatesRequest">
+        <wsdl:part element="typens:xcoreSalesOrderStatesRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreSalesOrderStatesResponse">
+        <wsdl:part element="typens:xcoreSalesOrderStatesResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreShippingMethodListRequest">
+        <wsdl:part element="typens:xcoreShippingMethodListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreShippingMethodListResponse">
+        <wsdl:part element="typens:xcoreShippingMethodListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreTaxClassProductListRequest">
+        <wsdl:part element="typens:xcoreTaxClassProductListRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreTaxClassProductListResponse">
+        <wsdl:part element="typens:xcoreTaxClassProductListResponseParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreVersionInfoRequest">
+        <wsdl:part element="typens:xcoreVersionInfoRequestParam" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="xcoreVersionInfoResponse">
+        <wsdl:part element="typens:xcoreVersionInfoResponseParam" name="parameters" />
     </wsdl:message>
     <wsdl:message name="xcoreWebsiteItemsRequest">
-        <wsdl:part name="parameters" element="typens:xcoreWebsiteItemsRequestParam" />
+        <wsdl:part element="typens:xcoreWebsiteItemsRequestParam" name="parameters" />
     </wsdl:message>
     <wsdl:message name="xcoreWebsiteItemsResponse">
-        <wsdl:part name="parameters" element="typens:xcoreWebsiteItemsResponseParam" />
+        <wsdl:part element="typens:xcoreWebsiteItemsResponseParam" name="parameters" />
     </wsdl:message>
-
     <wsdl:portType name="{{var wsdl.handler}}PortType">
-        <wsdl:operation name="xcoreTaxClassProductList">
-            <wsdl:documentation>Create tier prices</wsdl:documentation>
-            <wsdl:input message="typens:xcoreTaxClassProductListRequest"/>
-            <wsdl:output message="typens:xcoreTaxClassProductListResponse"/>
-        </wsdl:operation>
         <wsdl:operation name="xcoreCatalogProductAttributeSetGroupInfo">
             <wsdl:documentation>Group Info</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCatalogProductAttributeSetGroupInfoRequest"/>
-            <wsdl:output message="typens:xcoreCatalogProductAttributeSetGroupInfoResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcorePaymentMethodList">
-            <wsdl:documentation>Group Info</wsdl:documentation>
-            <wsdl:input message="typens:xcorePaymentMethodListRequest"/>
-            <wsdl:output message="typens:xcorePaymentMethodListResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreShippingMethodList">
-            <wsdl:documentation>Group Info</wsdl:documentation>
-            <wsdl:input message="typens:xcoreShippingMethodListRequest"/>
-            <wsdl:output message="typens:xcoreShippingMethodListResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreSalesOrderStates">
-            <wsdl:documentation>Group Info</wsdl:documentation>
-            <wsdl:input message="typens:xcoreSalesOrderStatesRequest"/>
-            <wsdl:output message="typens:xcoreSalesOrderStatesResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreVersionInfo">
-            <wsdl:documentation>Group Info</wsdl:documentation>
-            <wsdl:input message="typens:xcoreVersionInfoRequest"/>
-            <wsdl:output message="typens:xcoreVersionInfoResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomItemAttributes">
-            <wsdl:documentation>List of custom xcore Item Attributes</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCustomItemAttributesRequest"/>
-            <wsdl:output message="typens:xcoreCustomItemAttributesResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomCustomerAttributes">
-            <wsdl:documentation>List of custom xcore Customer Attributes</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCustomCustomerAttributesRequest"/>
-            <wsdl:output message="typens:xcoreCustomCustomerAttributesResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomSaleAttributes">
-            <wsdl:documentation>List of custom xcore Sale Attributes</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCustomSaleAttributesRequest"/>
-            <wsdl:output message="typens:xcoreCustomSaleAttributesResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomInvoiceAttributes">
-            <wsdl:documentation>List of custom xcore Invoice Attributes</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCustomInvoiceAttributesRequest"/>
-            <wsdl:output message="typens:xcoreCustomInvoiceAttributesResponse"/>
+            <wsdl:input message="typens:xcoreCatalogProductAttributeSetGroupInfoRequest" />
+            <wsdl:output message="typens:xcoreCatalogProductAttributeSetGroupInfoResponse" />
         </wsdl:operation>
         <wsdl:operation name="xcoreCustomCreditAttributes">
             <wsdl:documentation>List of custom xcore Credit Attributes</wsdl:documentation>
-            <wsdl:input message="typens:xcoreCustomCreditAttributesRequest"/>
-            <wsdl:output message="typens:xcoreCustomCreditAttributesResponse"/>
+            <wsdl:input message="typens:xcoreCustomCreditAttributesRequest" />
+            <wsdl:output message="typens:xcoreCustomCreditAttributesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomCustomerAttributes">
+            <wsdl:documentation>List of custom xcore Customer Attributes</wsdl:documentation>
+            <wsdl:input message="typens:xcoreCustomCustomerAttributesRequest" />
+            <wsdl:output message="typens:xcoreCustomCustomerAttributesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomCustomerList">
+            <wsdl:documentation>List of custom xcore Customer Attributes</wsdl:documentation>
+            <wsdl:input message="typens:xcoreCustomCustomerListRequest" />
+            <wsdl:output message="typens:xcoreCustomCustomerListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomInvoiceAttributes">
+            <wsdl:documentation>List of custom xcore Invoice Attributes</wsdl:documentation>
+            <wsdl:input message="typens:xcoreCustomInvoiceAttributesRequest" />
+            <wsdl:output message="typens:xcoreCustomInvoiceAttributesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomItemAttributes">
+            <wsdl:documentation>List of custom xcore Item Attributes</wsdl:documentation>
+            <wsdl:input message="typens:xcoreCustomItemAttributesRequest" />
+            <wsdl:output message="typens:xcoreCustomItemAttributesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomSaleAttributes">
+            <wsdl:documentation>List of custom xcore Sale Attributes</wsdl:documentation>
+            <wsdl:input message="typens:xcoreCustomSaleAttributesRequest" />
+            <wsdl:output message="typens:xcoreCustomSaleAttributesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcorePaymentMethodList">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcorePaymentMethodListRequest" />
+            <wsdl:output message="typens:xcorePaymentMethodListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderCreditmemoList">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreSalesOrderCreditmemoListRequest" />
+            <wsdl:output message="typens:xcoreSalesOrderCreditmemoListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderList">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreSalesOrderListRequest" />
+            <wsdl:output message="typens:xcoreSalesOrderListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderShipmentList">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreSalesOrderShipmentListRequest" />
+            <wsdl:output message="typens:xcoreSalesOrderShipmentListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderStates">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreSalesOrderStatesRequest" />
+            <wsdl:output message="typens:xcoreSalesOrderStatesResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreShippingMethodList">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreShippingMethodListRequest" />
+            <wsdl:output message="typens:xcoreShippingMethodListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreTaxClassProductList">
+            <wsdl:documentation>Create tier prices</wsdl:documentation>
+            <wsdl:input message="typens:xcoreTaxClassProductListRequest" />
+            <wsdl:output message="typens:xcoreTaxClassProductListResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="xcoreVersionInfo">
+            <wsdl:documentation>Group Info</wsdl:documentation>
+            <wsdl:input message="typens:xcoreVersionInfoRequest" />
+            <wsdl:output message="typens:xcoreVersionInfoResponse" />
         </wsdl:operation>
         <wsdl:operation name="xcoreWebsiteItems">
             <wsdl:documentation>List of websites</wsdl:documentation>
-            <wsdl:input message="typens:xcoreWebsiteItemsRequest"/>
-            <wsdl:output message="typens:xcoreWebsiteItemsResponse"/>
+            <wsdl:input message="typens:xcoreWebsiteItemsRequest" />
+            <wsdl:output message="typens:xcoreWebsiteItemsResponse" />
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="{{var wsdl.handler}}Binding" type="typens:{{var wsdl.handler}}PortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
-        <wsdl:operation name="xcoreTaxClassProductList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
         <wsdl:operation name="xcoreCatalogProductAttributeSetGroupInfo">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcorePaymentMethodList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreShippingMethodList">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreSalesOrderStates">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreVersionInfo">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomItemAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomCustomerAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomSaleAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="xcoreCustomInvoiceAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
-            <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="xcoreCustomCreditAttributes">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomCustomerAttributes">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomInvoiceAttributes">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomItemAttributes">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreCustomSaleAttributes">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcorePaymentMethodList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderCreditmemoList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderShipmentList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreSalesOrderStates">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreShippingMethodList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreTaxClassProductList">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="xcoreVersionInfo">
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
+            </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="xcoreWebsiteItems">
-            <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <wsdl:input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:input>
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <wsdl:output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:{{var wsdl.name}}" use="encoded" />
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-
     <wsdl:service name="{{var wsdl.name}}Service">
-        <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
+        <wsdl:port binding="typens:{{var wsdl.handler}}Binding" name="{{var wsdl.handler}}Port">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>
-
-


### PR DESCRIPTION
New methods added to request orders, creditmemos and shipments with a limit (`xcoreSalesOrderList`, `xcoreSalesOrderCreditmemoList` and `xcoreSalesOrderShipmentList`).

The method 'xcoreCustomerCustomerList` doesn't function, neither does the `Info` on that model. Didn't seem to have ever functioned, and I'm unsure why. The methods are mentioned in the API. Not yet in the WSI.