### PR TITLE
Removed potential object injection from Helper

### DIFF
--- a/app/code/local/Dealer4dealer/Xcore/Helper/Data.php
+++ b/app/code/local/Dealer4dealer/Xcore/Helper/Data.php
@@ -64,11 +64,20 @@ class Dealer4dealer_Xcore_Helper_Data extends Mage_Core_Helper_Abstract
     public function getMappingData($sysconKey, $storeId = null)
     {
         $mapping = Mage::getStoreConfig($sysconKey, $storeId);
-        if ($mapping) {
-            $mapping = unserialize($mapping);
-            return array_values((array)$mapping); // cast to array and strip any keys
+        if (! $mapping) {
+            return [];
         }
 
+        try {
+            $mapping = Mage::helper('core/unserializeArray')
+                ->unserialize($mapping);
+
+            return $mapping;
+        } catch (Exception $e) {
+            Mage::logException($e);
+        }
+
+        // Something went wrong unserializing
         return [];
     }
 


### PR DESCRIPTION
When using unserialize without additional checks it's possible to inject a specially crafted string which will 
execute on deserialization

https://www.owasp.org/index.php/PHP_Object_Injection

Mage::helper('core/unserializeArray') protects against this type of injection